### PR TITLE
BF Added instance detachment on scene change

### DIFF
--- a/Packages/com.lookingglass.joyconlib/JoyconLib_scripts/#JoyconManager.cs#
+++ b/Packages/com.lookingglass.joyconlib/JoyconLib_scripts/#JoyconManager.cs#
@@ -1,0 +1,105 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+using System;
+public class JoyconManager: MonoBehaviour
+{
+
+    // Settings accessible via Unity
+    public bool EnableIMU = true;
+    public bool EnableLocalize = true;
+
+	// Different operating systems either do or don't like the trailing zero
+	private const ushort vendor_id = 0x57e;
+	private const ushort vendor_id_ = 0x057e;
+	private const ushort product_l = 0x2006;
+	private const ushort product_r = 0x2007;
+
+    public List<Joycon> j; // Array of all connected Joy-Cons
+    static JoyconManager instance;
+
+    public static JoyconManager Instance
+    {
+        get { return instance; }
+    }
+
+    void Awake()
+    {
+        if (instance != null) Destroy(gameObject);
+        instance = this;
+		int i = 0;
+
+		j = new List<Joycon>();
+		bool isLeft = false;
+		HIDapi.hid_init();
+
+		IntPtr ptr = HIDapi.hid_enumerate(vendor_id, 0x0);
+		IntPtr top_ptr = ptr;
+
+		if (ptr == IntPtr.Zero)
+		{
+			ptr = HIDapi.hid_enumerate(vendor_id_, 0x0);
+			if (ptr == IntPtr.Zero)
+			{ 
+				HIDapi.hid_free_enumeration(ptr);
+				Debug.Log ("No Joy-Cons found!");
+			}
+		}
+		hid_device_info enumerate;
+		while (ptr != IntPtr.Zero) {
+			enumerate = (hid_device_info)Marshal.PtrToStructure (ptr, typeof(hid_device_info));
+
+			Debug.Log (enumerate.product_id);
+				if (enumerate.product_id == product_l || enumerate.product_id == product_r) {
+					if (enumerate.product_id == product_l) {
+						isLeft = true;
+						Debug.Log ("Left Joy-Con connected.");
+					} else if (enumerate.product_id == product_r) {
+						isLeft = false;
+						Debug.Log ("Right Joy-Con connected.");
+					} else {
+						Debug.Log ("Non Joy-Con input device skipped.");
+					}
+					IntPtr handle = HIDapi.hid_open_path (enumerate.path);
+					HIDapi.hid_set_nonblocking (handle, 1);
+					j.Add (new Joycon (handle, EnableIMU, EnableLocalize & EnableIMU, 0.05f, isLeft));
+					++i;
+				}
+				ptr = enumerate.next;
+			}
+		HIDapi.hid_free_enumeration (top_ptr);
+    }
+
+    void Start()
+    {
+		for (int i = 0; i < j.Count; ++i)
+		{
+			Debug.Log (i);
+			Joycon jc = j [i];
+			byte LEDs = 0x0;
+			LEDs |= (byte)(0x1 << i);
+			jc.Attach (leds_: LEDs);
+			jc.Begin ();
+		}
+    }
+
+    void Update()
+    {
+		for (int i = 0; i < j.Count; ++i)
+		{
+			j[i].Update();
+		}
+    }
+
+    void OnApplicationQuit()
+    {
+		for (int i = 0; i < j.Count; ++i)
+		{
+			j[i].Detach ();
+		}
+    }
+}

--- a/Packages/com.lookingglass.joyconlib/JoyconLib_scripts/JoyconManager.cs
+++ b/Packages/com.lookingglass.joyconlib/JoyconLib_scripts/JoyconManager.cs
@@ -3,19 +3,20 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using System;
-public class JoyconManager: MonoBehaviour
+public class JoyconManager : MonoBehaviour
 {
 
     // Settings accessible via Unity
     public bool EnableIMU = true;
     public bool EnableLocalize = true;
 
-	// Different operating systems either do or don't like the trailing zero
-	private const ushort vendor_id = 0x57e;
-	private const ushort vendor_id_ = 0x057e;
-	private const ushort product_l = 0x2006;
-	private const ushort product_r = 0x2007;
+    // Different operating systems either do or don't like the trailing zero
+    private const ushort vendor_id = 0x57e;
+    private const ushort vendor_id_ = 0x057e;
+    private const ushort product_l = 0x2006;
+    private const ushort product_r = 0x2007;
 
     public List<Joycon> j; // Array of all connected Joy-Cons
     static JoyconManager instance;
@@ -29,75 +30,97 @@ public class JoyconManager: MonoBehaviour
     {
         if (instance != null) Destroy(gameObject);
         instance = this;
-		int i = 0;
+        int i = 0;
 
-		j = new List<Joycon>();
-		bool isLeft = false;
-		HIDapi.hid_init();
+        j = new List<Joycon>();
+        bool isLeft = false;
+        HIDapi.hid_init();
 
-		IntPtr ptr = HIDapi.hid_enumerate(vendor_id, 0x0);
-		IntPtr top_ptr = ptr;
+        IntPtr ptr = HIDapi.hid_enumerate(vendor_id, 0x0);
+        IntPtr top_ptr = ptr;
 
-		if (ptr == IntPtr.Zero)
-		{
-			ptr = HIDapi.hid_enumerate(vendor_id_, 0x0);
-			if (ptr == IntPtr.Zero)
-			{ 
-				HIDapi.hid_free_enumeration(ptr);
-				Debug.Log ("No Joy-Cons found!");
-			}
-		}
-		hid_device_info enumerate;
-		while (ptr != IntPtr.Zero) {
-			enumerate = (hid_device_info)Marshal.PtrToStructure (ptr, typeof(hid_device_info));
+        if (ptr == IntPtr.Zero)
+        {
+            ptr = HIDapi.hid_enumerate(vendor_id_, 0x0);
+            if (ptr == IntPtr.Zero)
+            {
+                HIDapi.hid_free_enumeration(ptr);
+                Debug.Log("No Joy-Cons found!");
+            }
+        }
+        hid_device_info enumerate;
+        while (ptr != IntPtr.Zero)
+        {
+            enumerate = (hid_device_info)Marshal.PtrToStructure(ptr, typeof(hid_device_info));
 
-			Debug.Log (enumerate.product_id);
-				if (enumerate.product_id == product_l || enumerate.product_id == product_r) {
-					if (enumerate.product_id == product_l) {
-						isLeft = true;
-						Debug.Log ("Left Joy-Con connected.");
-					} else if (enumerate.product_id == product_r) {
-						isLeft = false;
-						Debug.Log ("Right Joy-Con connected.");
-					} else {
-						Debug.Log ("Non Joy-Con input device skipped.");
-					}
-					IntPtr handle = HIDapi.hid_open_path (enumerate.path);
-					HIDapi.hid_set_nonblocking (handle, 1);
-					j.Add (new Joycon (handle, EnableIMU, EnableLocalize & EnableIMU, 0.05f, isLeft));
-					++i;
-				}
-				ptr = enumerate.next;
-			}
-		HIDapi.hid_free_enumeration (top_ptr);
+            Debug.Log(enumerate.product_id);
+            if (enumerate.product_id == product_l || enumerate.product_id == product_r)
+            {
+                if (enumerate.product_id == product_l)
+                {
+                    isLeft = true;
+                    Debug.Log("Left Joy-Con connected.");
+                }
+                else if (enumerate.product_id == product_r)
+                {
+                    isLeft = false;
+                    Debug.Log("Right Joy-Con connected.");
+                }
+                else
+                {
+                    Debug.Log("Non Joy-Con input device skipped.");
+                }
+                IntPtr handle = HIDapi.hid_open_path(enumerate.path);
+                HIDapi.hid_set_nonblocking(handle, 1);
+                j.Add(new Joycon(handle, EnableIMU, EnableLocalize & EnableIMU, 0.05f, isLeft));
+                ++i;
+            }
+            ptr = enumerate.next;
+        }
+        HIDapi.hid_free_enumeration(top_ptr);
     }
 
     void Start()
     {
-		for (int i = 0; i < j.Count; ++i)
-		{
-			Debug.Log (i);
-			Joycon jc = j [i];
-			byte LEDs = 0x0;
-			LEDs |= (byte)(0x1 << i);
-			jc.Attach (leds_: LEDs);
-			jc.Begin ();
-		}
+        SceneManager.sceneUnloaded += OnSceneUnloaded;
+        for (int i = 0; i < j.Count; ++i)
+        {
+            Debug.Log(i);
+            Joycon jc = j[i];
+            byte LEDs = 0x0;
+            LEDs |= (byte)(0x1 << i);
+            jc.Attach(leds_: LEDs);
+            jc.Begin();
+        }
     }
 
     void Update()
     {
-		for (int i = 0; i < j.Count; ++i)
-		{
-			j[i].Update();
-		}
+        for (int i = 0; i < j.Count; ++i)
+        {
+            j[i].Update();
+        }
     }
+
+    private void OnDestroy()
+    {
+
+    }
+
+    private void OnSceneUnloaded(Scene current)
+    {
+        for (int i = 0; i < j.Count; ++i)
+        {
+            j[i].Detach();
+        }
+    }
+
 
     void OnApplicationQuit()
     {
-		for (int i = 0; i < j.Count; ++i)
-		{
-			j[i].Detach ();
-		}
+        for (int i = 0; i < j.Count; ++i)
+        {
+            j[i].Detach();
+        }
     }
 }


### PR DESCRIPTION
Related to issue #15 - The instance of JoyconManager was only detached on quitting the application.  I've added a few lines that check for a scene change and then detach  the JoyCons.  It doesn't crash now.
