### PR TITLE
Fix string formatting

### DIFF
--- a/Packages/com.lookingglass.joyconlib/JoyconLib_scripts/Joycon.cs
+++ b/Packages/com.lookingglass.joyconlib/JoyconLib_scripts/Joycon.cs
@@ -373,7 +373,7 @@ public class Joycon
                     DebugPrint(string.Format("Duplicate timestamp dequeued. TS: {0:X2}", ts_de), DebugType.THREADING);
                 }
                 ts_de = report_buf[1];
-                DebugPrint(string.Format("Dequeue. Queue length: {0:d}. Packet ID: {1:X2}. Timestamp: {2:X2}. Lag to dequeue: {3:s}. Lag between packets (expect 15ms): {4:s}",
+                DebugPrint(string.Format("Dequeue. Queue length: {0:d}. Packet ID: {1:X2}. Timestamp: {2:X2}. Lag to dequeue: {3:t}. Lag between packets (expect 15ms): {4:g}",
                     reports.Count, report_buf[0], report_buf[1], System.DateTime.Now.Subtract(rep.GetTime()), rep.GetTime().Subtract(ts_prev)), DebugType.THREADING);
                 ts_prev = rep.GetTime();
             }


### PR DESCRIPTION
Need to use time formatting for the debug log, otherwise it shows an `Input string was not in a correct format` error

Fixes https://github.com/Looking-Glass/JoyconLib/issues/23

Original fix from @UlyssesWu